### PR TITLE
Do not run `pip install` in verbose mode

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12' --extra-pip-arg='--verbose'
+DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12'
 
 distclean:
 	rm -Rf build debian/portal/ env


### PR DESCRIPTION
* Prevent TravisCI from killing jobs due to log length (27000/4MB+?)