### PR TITLE
add babel polyfill dependency for building js bundle

### DIFF
--- a/portal/.babelrc
+++ b/portal/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     ["@babel/env", {
-      "modules": false
+      "modules": false,
+      "useBuiltIns": "usage",
     }]
   ],
   "plugins": ["syntax-dynamic-import"]

--- a/portal/package.json
+++ b/portal/package.json
@@ -10,6 +10,9 @@
   },
   "author": "Amy",
   "license": "BSD",
+  "dependencies": {
+    "@babel/polyfill": "^7.2.5"
+  },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",


### PR DESCRIPTION
some ES2016 features are generating runtime error (e.g. Promise, generator function, async/wait) in some browsers (e.g. IE)

Need to include polyfill code when building bundled JS -  allows using the full set of ES6 features - note the polyfill code is only added on usage - Babel will optimize and only include the polyfill needed. (see: https://babeljs.io/docs/en/babel-polyfill)

