### PR TITLE
Feature/assessment status as of date

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1795,8 +1795,8 @@ def patient_assessment_status(patient_id):
     current_user().check_role(permission='view', other_id=patient_id)
 
     date = request.args.get('as_of_date')
-    # allow date and time info to be available
     date = FHIR_datetime.parse(date) if date else datetime.utcnow()
+
     trace = request.args.get('trace', False)
     if trace:
         establish_trace(


### PR DESCRIPTION
Now merging into RC - provides the `as_of_date` parameter for live debugging of a user's assessment status.