### PR TITLE
Regenerate Lockfile for Python Dependencies

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -24,7 +24,7 @@ babel==2.9.0
     #   flask-babel
     #   portal (setup.cfg)
     #   sphinx
-bcrypt==3.2.0
+bcrypt==4.0.1
     # via
     #   flask-user
     #   portal (setup.cfg)
@@ -46,8 +46,6 @@ certifi==2025.7.14
     # via
     #   requests
     #   selenium
-cffi==1.17.1
-    # via bcrypt
 charset-normalizer==3.4.2
     # via requests
 click==8.1.7
@@ -186,7 +184,7 @@ lazy==1.6
     # via flask-dance
 mako==1.3.10
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
@@ -229,8 +227,6 @@ psycopg2-binary==2.8.6
     # via portal (setup.cfg)
 py==1.11.0
     # via tox
-pycparser==2.22
-    # via cffi
 pycryptodome==3.23.0
     # via flask-user
 pygments==2.19.2
@@ -290,7 +286,6 @@ selenium==4.34.2
     #   portal (setup.cfg)
 six==1.17.0
     # via
-    #   bcrypt
     #   flask-dance
     #   jsonschema
     #   onetimepass

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,7 +142,6 @@ markupsafe==2.0.1
     #   jinja2
     #   mako
     #   portal (setup.cfg)
-    #   wtforms
 oauthlib==2.1.0
     # via
     #   flask-dance
@@ -236,8 +235,10 @@ werkzeug==1.0.1
     # via
     #   flask
     #   portal (setup.cfg)
-wtforms==3.2.1
-    # via flask-wtf
+wtforms==2.2.1
+    # via
+    #   flask-wtf
+    #   portal (setup.cfg)
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ install_requires =
     markupsafe<2.1.0
     # our version of flask-sqlalchemy requires older version of werkzeug
     werkzeug<2.0.0
+    wtforms==2.2.1
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
- Add all direct dependencies to `setup.cfg`
  - Copy versions from lockfiles (`requirements.txt`, `requirements.dev.txt`) as necessary
- Regenerate lockfiles from `setup.cfg` with `pip-compile`
  - Removes unused transient dependencies
  - Upgrades transient dependencies

See [TN-3347](https://movember.atlassian.net/browse/TN-3347)