### PR TITLE
grant researchers access to view for filesystem reports

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -889,6 +889,9 @@ def aggregate_responses(
     total = query.count()
     if instrument_ids:
         query = query.filter(ResearchData.instrument.in_(tuple(instrument_ids)))
+        instrument_label = '-'.join(instrument_ids)
+    else:
+        instrument_label = ""
 
     suffix = ".csv"
     header = qnr_csv_column_headers
@@ -901,7 +904,7 @@ def aggregate_responses(
         dir=current_app.config['TMP_REPORT_DIR'],
         mode="w",
         newline="",
-        prefix=f"qnr-data-{datetime.today().strftime('%Y-%m-%d')}-",
+        prefix=f"qnr-data-{instrument_label}-{datetime.today().strftime('%Y-%m-%d')}-",
         suffix=suffix,
         delete=False)
     if bundle_format:

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -336,7 +336,7 @@ def questionnaire_status():
 
 
 @reporting_api.route('/research/<filename>')
-@roles_required([ROLE.ADMIN.value, ROLE.ANALYST.value])
+@roles_required([ROLE.ADMIN.value, ROLE.RESEARCHER.value])
 @oauth.require_oauth()
 def expose_report_download(filename):
     """Direct access to files generated via research_report_task"""


### PR DESCRIPTION
correct role used to download research reports from the filesystem.  (should have been `researcher`, not `analyst`)