### PR TITLE
Hotfix/port timeline new cache

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -852,6 +852,14 @@ def row_by_format(data, bundle_format):
         yield from generate_qnr_csv(data)
 
 
+def bundle_from_aggregate_responses(**kwargs):
+    kwargs.update({'bundle_format': True})
+    filename = aggregate_responses(**kwargs)
+    with open(filename, 'r') as fh:
+        bundle = json.load(fh)
+    return bundle
+
+
 def aggregate_responses(
         instrument_ids, current_user, celery_task=None, patient_ids=None, bundle_format=False):
     """Build a bundle of QuestionnaireResponses in a temporary file

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -485,7 +485,7 @@ def patient_timeline(patient_id):
     }
     qnr_responses = bundle_from_aggregate_responses(**agg_args)
 
-    if qnr_responses['total'] == 0:
+    if len(qnr_responses.get('entry', [])) == 0:
         from ..models.research_data import update_single_patient_research_data
         update_single_patient_research_data(patient_id)
         qnr_responses = bundle_from_aggregate_responses(**agg_args)

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -330,7 +330,7 @@ def patient_timeline(patient_id):
     from ..models.qbd import QBD
     from ..models.qb_status import QB_Status
     from ..models.questionnaire_bank import translate_visit_name, visit_name
-    from ..models.questionnaire_response import aggregate_responses
+    from ..models.questionnaire_response import bundle_from_aggregate_responses
     from ..models.research_protocol import ResearchProtocol
     from ..tasks import cache_single_patient_adherence_data
     from ..trace import dump_trace, establish_trace
@@ -483,12 +483,12 @@ def patient_timeline(patient_id):
         'current_user': current_user(),
         'patient_ids': [patient_id],
     }
-    qnr_responses = aggregate_responses(**agg_args)
+    qnr_responses = bundle_from_aggregate_responses(**agg_args)
 
     if qnr_responses['total'] == 0:
         from ..models.research_data import update_single_patient_research_data
         update_single_patient_research_data(patient_id)
-        qnr_responses = aggregate_responses(**agg_args)
+        qnr_responses = bundle_from_aggregate_responses(**agg_args)
 
     # filter qnr data to a manageable result data set
     qnr_data = []

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -28,7 +28,7 @@ from portal.models.questionnaire_bank import (
 from portal.models.questionnaire_response import (
     QNR_results,
     QuestionnaireResponse,
-    aggregate_responses,
+    bundle_from_aggregate_responses,
     qnr_document_id,
 )
 from portal.models.recur import Recur
@@ -337,12 +337,10 @@ class TestAggregateResponses(TestQuestionnaireSetup):
         # only the latest to the research data cache.  flush and add all
         invalidate_patient_research_data(TEST_USER_ID, research_study_id=0)
         update_single_patient_research_data(TEST_USER_ID)
-        filename = aggregate_responses(
+        bundle = bundle_from_aggregate_responses(
             instrument_ids=[instrument_id],
             current_user=staff,
             bundle_format=True)
-        with open(filename, 'r') as f:
-            bundle = json.load(f)
         expected = {'Baseline', 'Month 3', 'Month 6', 'Month 9'}
         found = [i['timepoint'] for i in bundle['entry']]
         assert set(found) == expected
@@ -380,10 +378,8 @@ class TestAggregateResponses(TestQuestionnaireSetup):
                 Organization.name == 'metastatic').one())
         self.promote_user(staff, role_name=ROLE.STAFF.value)
         staff = db.session.merge(staff)
-        filepath = aggregate_responses(
+        bundle = bundle_from_aggregate_responses(
             instrument_ids=[instrument_id], current_user=staff, bundle_format=True)
-        with open(filepath, 'r') as f:
-            bundle = json.load(f)
         id1 = db.session.merge(id1)
         assert 1 == len(bundle['entry'])
         assert (1 ==


### PR DESCRIPTION
The `/timeline` view raises server errors as the code hasn't been ported to use the filesystem results from `aggregate_responses()` as altered in #4480 

Corrected via new helper function `bundle_from_aggregate_responses()`, used in both previously refactored tests and the `/timeline` view.