### PR TITLE
Do not ignore NodeJS lockfile for docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,7 +41,6 @@ portal/static/css/*.css
 # nodeJS virtual environment and files
 node_env/
 portal/node_modules/
-portal/package-lock.json
 
 # auto-generated JS eslint config when linting JS files (via command eslint) at development
 portal/static/js/.eslintrc.js


### PR DESCRIPTION
Do not ignore NodeJS lockfile for docker builds
Without a lockfile, `npm install` will update to latest dependencies possible